### PR TITLE
Use rename libyui REST API client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,4 @@ gemspec
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"
 
-gem "libyui_client", path: "/home/jrivera/Code/libyui_client"
+gem "yui_rest_client"

--- a/lib/libyui_test_framework.rb
+++ b/lib/libyui_test_framework.rb
@@ -9,6 +9,6 @@ module LibyuiTestFramework
   end
 
   # def self.logger
-  #   @logger ||= LibyuiClient::Logger.new
+  #   @logger ||= YuiRestClient::Logger.new
   # end
 end

--- a/libyui_test_framework.gemspec
+++ b/libyui_test_framework.gemspec
@@ -10,8 +10,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Joaquín Rivera"]
   # spec.email         = ["jeriveramoya@suse.com"]
 
-  spec.summary       = 'Automation Framework using libyui_client.'
-  spec.description   = 'Automation Framework using libyui_client.'
+  spec.summary       = 'Automation Framework using yui_rest_client.'
+  spec.description   = 'Automation Framework using yui_rest_client.'
   spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
 

--- a/spec/expert_partitioner/expert_partitioner_spec.rb
+++ b/spec/expert_partitioner/expert_partitioner_spec.rb
@@ -1,13 +1,13 @@
 require 'rspec'
-require 'libyui_client'
+require 'yui_rest_client'
 require 'libyui_test_framework'
 
 module LibyuiTestFramework
   RSpec.describe "Once Expert partitioner is launched" do
     before :all do
-      @app = LibyuiClient::App.new(host: '192.168.200.146' , port: '9999')
+      @app = YuiRestClient::App.new(host: '192.168.200.146' , port: '9999')
       
-      local_process = LibyuiClient::LocalProcess.new
+      local_process = YuiRestClient::LocalProcess.new
       local_process.start_app('YUI_REUSE_PORT=1 YUI_HTTP_PORT=9999 yast2 partitioner --qt')
       local_process.start_app("xterm -e 'YUI_REUSE_PORT=1 YUI_HTTP_PORT=9999 yast2 partitioner --ncurses'")
       


### PR DESCRIPTION
We have renamed our gem to yui_rest_client, therefore updating
references in this repo too.

https://github.com/qe-yast/ruby-yui-rest-client/pull/30 has to be merged first.