### PR TITLE
 Move methods to start app to the tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.gem
+*.rbc
 /.bundle/
 /.yardoc
 /_yardoc/

--- a/lib/libyui_test_framework.rb
+++ b/lib/libyui_test_framework.rb
@@ -1,14 +1,9 @@
 # frozen_string_literal: true
 
 require 'libyui_test_framework/distributions'
+require 'libyui_test_framework/helpers'
 require 'libyui_test_framework/version'
 
 # Client to interact with YAST UI rest api framework for integration testing
 module LibyuiTestFramework
-  class << self
-  end
-
-  # def self.logger
-  #   @logger ||= YuiRestClient::Logger.new
-  # end
 end

--- a/lib/libyui_test_framework/helpers.rb
+++ b/lib/libyui_test_framework/helpers.rb
@@ -1,0 +1,17 @@
+module LibyuiTestFramework
+  module Helpers
+    require 'libyui_test_framework/helpers/local_module_helper'
+    # wait until condition returns result, can be used, for instance,
+    # to assert that new entry was added to the table, as doesn't appear
+    # immediatelly
+    # @example:
+    #   expect(wait_until { table.items.include?(new_entry) }).to be(true), "New entry is not shown"
+    def wait_until(condition: nil)
+      YuiRestClient::Wait.until(timeout: YuiRestClient.timeout, interval: YuiRestClient.interval) do
+        result = yield(condition)
+        return result if result
+      end
+      nil
+    end
+  end
+end

--- a/lib/libyui_test_framework/helpers/local_module_helper.rb
+++ b/lib/libyui_test_framework/helpers/local_module_helper.rb
@@ -1,0 +1,44 @@
+module LibyuiTestFramework
+  module Helpers
+    class LocalModule
+
+        def initialize(port:, name:)
+          @port = port
+          @name = name
+          @app_pid = nil
+        end
+
+        def start_ncurses
+          start(cmd: "xterm -e 'YUI_REUSE_PORT=1 YUI_HTTP_PORT=#{@port} yast2 #{@name} --ncurses'")
+        end
+
+        def start_qt
+          start(cmd: "YUI_REUSE_PORT=1 YUI_HTTP_PORT=#{@port} yast2 #{@name} --qt")
+        end
+
+        # start the application in background
+        def start(cmd:)
+          YuiRestClient.logger.debug("Starting #{cmd}...")
+          # create a new process group so easily we will be able
+          # to kill all its sub-processes
+          @app_pid = Process.spawn(cmd, pgroup: true)
+          YuiRestClient.logger.debug("App started: '#{cmd}'")
+          self
+        end
+
+        # kill the process if it is still running after finishing a scenario
+        def kill
+          return self unless @app_pid
+
+          Process.waitpid(@app_pid, Process::WNOHANG)
+          YuiRestClient.logger.debug("Sending KILL signal for PID #{@app_pid}")
+          Process.kill('-KILL', @app_pid)
+          self
+        rescue Errno::ECHILD, Errno::ESRCH
+          # the process has already exited
+          @app_pid = nil
+          self
+        end
+    end
+  end
+end

--- a/spec/expert_partitioner/expert_partitioner_spec.rb
+++ b/spec/expert_partitioner/expert_partitioner_spec.rb
@@ -5,19 +5,20 @@ require 'libyui_test_framework'
 module LibyuiTestFramework
   RSpec.describe "Once Expert partitioner is launched" do
     before :all do
-      @app = YuiRestClient::App.new(host: '192.168.200.146' , port: '9999')
-      
-      local_process = YuiRestClient::LocalProcess.new
-      local_process.start_app('YUI_REUSE_PORT=1 YUI_HTTP_PORT=9999 yast2 partitioner --qt')
-      local_process.start_app("xterm -e 'YUI_REUSE_PORT=1 YUI_HTTP_PORT=9999 yast2 partitioner --ncurses'")
-      
+      port = '9999'
+      @app = YuiRestClient::App.new(host: 'localhost' , port: port)
+
+      @local_process = Helpers::LocalModule.new(port: port, name: 'partitioner')
+      @local_process.start_qt
+
       @distri = Distributions::DistributionProvider.provide
       @expert_partitioner = @distri.get_expert_partitioner(@app)
+      @app.connect
     end
 
     after :all do
       # ensure module is closed
-      @local_process.kill_app
+      @local_process.kill
     end
 
     it "creates default partitioning on 2nd disk" do


### PR DESCRIPTION
We have agreed that client should provide interfaces to work with REST
API and leave part of setting up the environment to the tests
themselves.

Introducing those methods here, to simplify starting the yast modules in
ncurses and qt.

See https://github.com/qe-yast/ruby-yui-rest-client/pull/32